### PR TITLE
Updated ansible role name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ None.
       roles:
         - { role: geerlingguy.apache }
         - { role: geerlingguy.php }
-        - { role: geerlingguy.apache-fastcgi-php }
+        - { role: geerlingguy.apache-php-fpm }
 
 ## License
 


### PR DESCRIPTION
Previously it read `geerlingguy.apache-fastcgi-php`

This appeared to be the old name of the role, the latest name is `geerlingguy.apache-php-fpm`
