### PR TITLE
Clarify `### RedHat 6 and 7` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For a full usage example with the `geerlingguy.apache` role, see the Example Pla
 
 ### RedHat/CentOS
 
-RedHat/CentOS 7 and 8 automatically install and enables mod_proxy_fcgi by default.
+RedHat/CentOS 7 and 8 automatically install and enable mod_proxy_fcgi by default.
 
 RedHat/CentOS 6 installs Apache 2.2, and is much harder to get configured with FastCGI, but here are two guides in case you need to support this use case:
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ When configuring your Apache virtual hosts, you can add the following line to an
 
 For a full usage example with the `geerlingguy.apache` role, see the Example Playbook later in this README.
 
-### RedHat 6 and 7
+### RedHat/CentOS
 
-RedHat/CentOS 7 automatically installs and enables mod_proxy_fcgi by default.
+RedHat/CentOS 7 and 8 automatically install and enables mod_proxy_fcgi by default.
 
 RedHat/CentOS 6 installs Apache 2.2, and is much harder to get configured with FastCGI, but here are two guides in case you need to support this use case:
 


### PR DESCRIPTION
I was a little confused when I first read the README because it didn't mention RedHat 8, so this PR fixes that. It might also make sense to clarify line 5 because the role doesn't actually do anything on RedHat-based systems.

Also, thank you for all for all of your opensource work, YouTube channel, and Ansible books! I really appreciate it.